### PR TITLE
add copyright headers

### DIFF
--- a/bootstrap/base/kubeflow-cm-localpathprovisioner.yaml
+++ b/bootstrap/base/kubeflow-cm-localpathprovisioner.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/bootstrap/base/kubeflow-cr-localpathprovisioner.yaml
+++ b/bootstrap/base/kubeflow-cr-localpathprovisioner.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/bootstrap/base/kubeflow-cr.yaml
+++ b/bootstrap/base/kubeflow-cr.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/bootstrap/base/kubeflow-crb-localpathprovisioner.yaml
+++ b/bootstrap/base/kubeflow-crb-localpathprovisioner.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/bootstrap/base/kubeflow-crb.yaml
+++ b/bootstrap/base/kubeflow-crb.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/bootstrap/base/kubeflow-crd-kubeflowoperator.yaml
+++ b/bootstrap/base/kubeflow-crd-kubeflowoperator.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/bootstrap/base/kubeflow-deploy-kubeflowoperator.yaml
+++ b/bootstrap/base/kubeflow-deploy-kubeflowoperator.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/bootstrap/base/kubeflow-deploy-localpathprovisioner.yaml
+++ b/bootstrap/base/kubeflow-deploy-localpathprovisioner.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bootstrap/base/kubeflow-imagepullsecret.yaml
+++ b/bootstrap/base/kubeflow-imagepullsecret.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bootstrap/base/kubeflow-namespace.yaml
+++ b/bootstrap/base/kubeflow-namespace.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/bootstrap/base/kubeflow-sa-localpathprovisioner.yaml
+++ b/bootstrap/base/kubeflow-sa-localpathprovisioner.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bootstrap/base/kubeflow-sa.yaml
+++ b/bootstrap/base/kubeflow-sa.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bootstrap/base/kubeflow-sc-localpathprovisioner.yaml
+++ b/bootstrap/base/kubeflow-sc-localpathprovisioner.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/bootstrap/base/kubeflow-spark-cr.yaml
+++ b/bootstrap/base/kubeflow-spark-cr.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/bootstrap/base/kustomization.yaml
+++ b/bootstrap/base/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/bootstrap/components/dex-cm-ldap/auth-ns.yaml
+++ b/bootstrap/components/dex-cm-ldap/auth-ns.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/bootstrap/components/dex-cm-ldap/entrypoint.sh
+++ b/bootstrap/components/dex-cm-ldap/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 pushd "$(dirname "${BASH_SOURCE[0]}")"
 PARENT_PATH="$(pwd -P)"

--- a/bootstrap/components/dex-cm-ldap/job.yaml
+++ b/bootstrap/components/dex-cm-ldap/job.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/bootstrap/components/dex-cm-ldap/kustomization.yaml
+++ b/bootstrap/components/dex-cm-ldap/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow-operator

--- a/bootstrap/components/hpecpconfig-patch/entrypoint.sh
+++ b/bootstrap/components/hpecpconfig-patch/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 kubectl patch -n hpecp hpecpconfig hpecp-global-config --type json -p '
 [

--- a/bootstrap/components/hpecpconfig-patch/job.yaml
+++ b/bootstrap/components/hpecpconfig-patch/job.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/bootstrap/components/hpecpconfig-patch/kustomization.yaml
+++ b/bootstrap/components/hpecpconfig-patch/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow-operator

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 set -e
 
 BASEDIR=$(dirname "$0")

--- a/bootstrap/overlays/app/kustomization.yaml
+++ b/bootstrap/overlays/app/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:

--- a/bootstrap/overlays/manifest/kustomization.yaml
+++ b/bootstrap/overlays/manifest/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:

--- a/bootstrap/uninstall.sh
+++ b/bootstrap/uninstall.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 set -e
 
 BASEDIR=$(dirname "$0")

--- a/manifests/kfdef/kfctl_hcp_istio/base/imagepullsecret.yaml
+++ b/manifests/kfdef/kfctl_hcp_istio/base/imagepullsecret.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/manifests/kfdef/kfctl_hcp_istio/base/kfctl_hcp_istio.yaml
+++ b/manifests/kfdef/kfctl_hcp_istio/base/kfctl_hcp_istio.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:

--- a/manifests/kfdef/kfctl_hcp_istio/base/kustomization.yaml
+++ b/manifests/kfdef/kfctl_hcp_istio/base/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/manifests/kfdef/kfctl_hcp_istio/base/namespace.yaml
+++ b/manifests/kfdef/kfctl_hcp_istio/base/namespace.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/manifests/kfdef/kfctl_hcp_istio/overlays/manifest-uri/kustomization.yaml
+++ b/manifests/kfdef/kfctl_hcp_istio/overlays/manifest-uri/kustomization.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:

--- a/manifests/kfdef/kfctl_hcp_istio/overlays/manifest-uri/manifest-repo-uri-patch.yaml
+++ b/manifests/kfdef/kfctl_hcp_istio/overlays/manifest-uri/manifest-repo-uri-patch.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:


### PR DESCRIPTION
In order to apply [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.html)  the next headers have been added to the source files.
> *.yaml
> *.sh

There are also examples of src headers on the  [https://www.apache.org/legal/src-headers.html](https://www.apache.org/legal/src-headers.html)

Not all files was updated due to recommendations from [here](https://www.apache.org/legal/src-headers.html).

> WHAT FILES IN AN APACHE RELEASE DO NOT REQUIRE A LICENSE HEADER?
> A file without any degree of creativity in either its literal elements or its structure is not protected by copyright law; therefore, such a file does not require a license header. If in doubt about the extent of the file's creativity, add the license header to the file.
