### PR TITLE
fix kustomization file in component/dex-cm-generator

### DIFF
--- a/bootstrap/components/dex-cm-ldap/kustomization.yaml
+++ b/bootstrap/components/dex-cm-ldap/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubeflow-operator
 resources:
 - auth-ns.yaml
 - job.yaml
 configMapGenerator:
 - name: dex-cm-generator
+  namespace: kubeflow-operator
   files:
     - entrypoint.sh
     - template.yaml


### PR DESCRIPTION
auth namespace (component/dex-cm-generator/auth-ns.yaml) was applyed incorrectly by kustomization file.
'kubectl kustomize ./component/dex-cm-generator' was generates namespace 'kubeflow-operator' instead 'auth'.